### PR TITLE
fix `requestPermission` behavior

### DIFF
--- a/runtimepermissionchecker/src/main/java/net/taptappun/taku/kobayashi/runtimepermissionchecker/RuntimePermissionChecker.java
+++ b/runtimepermissionchecker/src/main/java/net/taptappun/taku/kobayashi/runtimepermissionchecker/RuntimePermissionChecker.java
@@ -62,7 +62,7 @@ public class RuntimePermissionChecker {
                     break;
                 }
             }
-            if(existPermission && RuntimePermissionChecker.hasSelfPermission(activity, permissionName)) {
+            if(existPermission && !RuntimePermissionChecker.hasSelfPermission(activity, permissionName)) {
                 activity.requestPermissions(new String[]{permissionName}, requestCode);
             }
         }

--- a/runtimepermissionchecker/src/main/java/net/taptappun/taku/kobayashi/runtimepermissionchecker/RuntimePermissionChecker.java
+++ b/runtimepermissionchecker/src/main/java/net/taptappun/taku/kobayashi/runtimepermissionchecker/RuntimePermissionChecker.java
@@ -57,7 +57,7 @@ public class RuntimePermissionChecker {
             ArrayList<PermissionInfo> permissions = RuntimePermissionChecker.getSettingPermissions(activity);
             for(int i = 0;i < permissions.size();++i){
                 PermissionInfo permission = permissions.get(i);
-                if(RuntimePermissionChecker.isDangerousPermission(permission) && permission.name == permissionName){
+                if(RuntimePermissionChecker.isDangerousPermission(permission) && permission.name.equals(permissionName)){
                     existPermission = true;
                     break;
                 }


### PR DESCRIPTION
## 1. Change string compare method, from '==' to 'equals'.
Since `==` is instance level comparison,  `requestPermission` doesn't request permission when it passes different string instance.

## 2. flip if statement
current code request permission if requested permission *EXISTS*, it should be requested when *NOT EXISTS*